### PR TITLE
src: Add back generate hyperlink to the project from commit

### DIFF
--- a/src/article_generator.py
+++ b/src/article_generator.py
@@ -1,4 +1,5 @@
 import datetime
+from src.git_utils import generate_commit_hyperlink
 from datetime import datetime
 
 def generate_article_content(commit_data: list[dict], months_back: int) -> str:
@@ -43,7 +44,8 @@ Here's a breakdown of key contributions by repository:
                 else "(No message)"
             )
             first_line_message = first_line_message.replace("_", r"\_")
-            article_content += f"- **{commit['author_name']}** on {commit['date'].split('T')[0]}: {first_line_message}\n"
+            hyperlink = generate_commit_hyperlink(repo['repo_path'], repo['repo_url'], commit['sha1'])
+            article_content += f"- **{commit['author_name']}** on {commit['date'].split('T')[0]}: [{first_line_message}]({hyperlink})\n"
 
         article_content += "\n"
 

--- a/src/git_utils.py
+++ b/src/git_utils.py
@@ -5,6 +5,41 @@ from datetime import datetime, timedelta
 from git import Repo, InvalidGitRepositoryError, NoSuchPathError, GitCommandError
 
 
+def generate_commit_hyperlink(repo_path, base_web_url, commit_hash_prefix):
+    """
+    Generates an hyperlink to a Git commit on a web platform.
+
+    Args:
+        repo_path (str): The path to the local Git repository.
+        base_web_url (str): The base URL for the repository on the web
+                            (e.g., "https://github.com/your_username/your_repo").
+        commit_hash_prefix (str): A full or partial commit hash.
+
+    Returns:
+        str: The hyperlink string, or None if the commit is not found.
+    """
+    try:
+        repo = Repo(repo_path)
+        commit = repo.commit(commit_hash_prefix)
+
+        commit_full_hash = commit.hexsha
+        commit_message = commit.summary
+
+        if base_web_url.startswith("https://git.kernel.org"):
+            commit_url = f"{base_web_url}/commit/?id={commit_full_hash}"
+        else:
+            if base_web_url.endswith(".git"):
+                base_web_url = base_web_url[:-4]
+            commit_url = f"{base_web_url}/commit/{commit_full_hash}"
+
+        hyperlink = f'{commit_url}'
+        return hyperlink
+
+    except Exception as e:
+        print(f"Error generating hyperlink: {e}")
+        return None
+
+
 def git_pull_or_clone(remote_url=None, repo_path="."):
     """
     Checks if a directory is a Git repository.
@@ -140,6 +175,7 @@ def analyze_real_git_commits(
                     {
                         "repo_name": repo_name,
                         "repo_url": repo_url,
+                        "repo_path": repo_path,
                         "error": f"Failed to clone: {error_msg}",
                         "commits": [],  # No commits if clone failed
                     }
@@ -153,6 +189,7 @@ def analyze_real_git_commits(
                     {
                         "repo_name": repo_name,
                         "repo_url": repo_url,
+                        "repo_path": repo_path,
                         "error": f"An unexpected error occurred during cloning: {str(e)}",
                         "commits": [],
                     }
@@ -172,6 +209,7 @@ def analyze_real_git_commits(
                     author_email = commit.author.email
                     commit_date = datetime.fromtimestamp(commit.authored_date).isoformat()
                     commit_message = commit.message.strip()
+                    sha1_hash = commit.hexsha
 
                     # Filter by company identifier (case-insensitive)
                     if (
@@ -185,6 +223,7 @@ def analyze_real_git_commits(
                                 "author_email": author_email,
                                 "date": commit_date,
                                 "message": commit_message,
+                                "sha1": sha1_hash,
                             }
                         )
 
@@ -192,6 +231,7 @@ def analyze_real_git_commits(
                     {
                         "repo_name": repo_name,
                         "repo_url": repo_url,
+                        "repo_path": repo_path,
                         "commits": repo_commits_list,
                     }
                 )
@@ -203,6 +243,7 @@ def analyze_real_git_commits(
                     {
                         "repo_name": repo_name,
                         "repo_url": repo_url,
+                        "repo_path": repo_path,
                         "error": f"Failed to get commit log: {error_msg}",
                         "commits": [],
                     }
@@ -213,6 +254,7 @@ def analyze_real_git_commits(
                     {
                         "repo_name": repo_name,
                         "repo_url": repo_url,
+                        "repo_path": repo_path,
                         "error": f"Error processing commits: {str(e)}",
                         "commits": [],
                     }


### PR DESCRIPTION
Implement back  commit d19844ad69d1.
Generate the link to the original commit message from the sha1. It's preferrable to use platform like github that are compatible with this link schema. Anyway most of the opensource repo has mirror on github. Add support even for kernel.org