### PR TITLE
article_generator: Fix the all_author_messages list

### DIFF
--- a/src/article_generator.py
+++ b/src/article_generator.py
@@ -50,7 +50,10 @@ Here's a breakdown of key contributions by repository:
             continue
 
         for author_name, author_commits in sorted(commits_by_author.items()):
-            all_author_messages = "\n".join([commit["message"] if commit["message"] else "(No message)"])
+            all_author_messages = "\n".join([
+                    commit["message"] if commit["message"] else "(No message provided)"
+                    for commit in author_commits
+                ])
 
             if openai_key:
                 ai_summary = summarize_commit_messages(openai_key, all_author_messages,


### PR DESCRIPTION
Before only the first commit was included in the list of commits to give to the AI to generate the summary. Adding the for loop insure that is taken them all.